### PR TITLE
add non-persistence flag for RS5

### DIFF
--- a/flexvolume/windows/plugins/microsoft.com~smb.cmd/smb.ps1
+++ b/flexvolume/windows/plugins/microsoft.com~smb.cmd/smb.ps1
@@ -43,7 +43,7 @@ function mount_command([string]$path, $options)
     $Credential = ConstructCredential -username $User -passPlain $passPlain
   
     Log  "smbGlobal"
-    $s = New-SmbGlobalMapping  -RemotePath $remoteP -Credential $Credential 2>&1
+    $s = New-SmbGlobalMapping  -RemotePath $remoteP -Credential $Credential -persistent $false 2>&1
     Log  $s
   
     MakeSymLink $path $remoteP


### PR DESCRIPTION
RS5 now has breaking change with new-smbglobalmapping are persisted by default & will error if already mapped. Setting with no persistence avoids this.